### PR TITLE
Make the package installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'testrpc=testrpc.__main__',
+            'testrpc=testrpc.__main__:main',
         ],
     }
 )

--- a/testrpc/__init__.py
+++ b/testrpc/__init__.py
@@ -1,2 +1,1 @@
 __version__ = '0.1.14'
-import testrpc

--- a/testrpc/__main__.py
+++ b/testrpc/__main__.py
@@ -49,4 +49,10 @@ server.register_function(web3_clientVersion, 'web3_clientVersion')
 server.register_function(evm_reset, 'evm_reset')
 server.register_function(evm_snapshot, 'evm_snapshot')
 server.register_function(evm_revert, 'evm_revert')
-server.serve_forever()
+
+def main():
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What was wrong?

When attempting to install the package from `pypi` I was getting this error

```bash
Building wheels for collected packages: eth-testrpc
  Running setup.py bdist_wheel for eth-testrpc
  Stored in directory: /Users/pipermerriam/Library/Caches/pip/wheels/4a/66/4d/28d73dd7a786188d87e628bf5753a163a5e8863d64460115fb
Successfully built eth-testrpc
Installing collected packages: eth-testrpc
Exception:
Traceback (most recent call last):
  File "/Users/pipermerriam/python-environments/eth-phone-number-verification/lib/python3.4/site-packages/pip/basecommand.py", line 223, in main
    status = self.run(options, args)
  File "/Users/pipermerriam/python-environments/eth-phone-number-verification/lib/python3.4/site-packages/pip/commands/install.py", line 297, in run
    root=options.root_path,
  File "/Users/pipermerriam/python-environments/eth-phone-number-verification/lib/python3.4/site-packages/pip/req/req_set.py", line 622, in install
    **kwargs
  File "/Users/pipermerriam/python-environments/eth-phone-number-verification/lib/python3.4/site-packages/pip/req/req_install.py", line 808, in install
    self.move_wheel_files(self.source_dir, root=root)
  File "/Users/pipermerriam/python-environments/eth-phone-number-verification/lib/python3.4/site-packages/pip/req/req_install.py", line 1003, in move_wheel_files
    isolated=self.isolated,
  File "/Users/pipermerriam/python-environments/eth-phone-number-verification/lib/python3.4/site-packages/pip/wheel.py", line 479, in move_wheel_files
    maker.make_multiple(['%s = %s' % kv for kv in console.items()])
  File "/Users/pipermerriam/python-environments/eth-phone-number-verification/lib/python3.4/site-packages/pip/_vendor/distlib/scripts.py", line 334, in make_multiple
    filenames.extend(self.make(specification, options))
  File "/Users/pipermerriam/python-environments/eth-phone-number-verification/lib/python3.4/site-packages/pip/_vendor/distlib/scripts.py", line 323, in make
    self._make_script(entry, filenames, options=options)
  File "/Users/pipermerriam/python-environments/eth-phone-number-verification/lib/python3.4/site-packages/pip/_vendor/distlib/scripts.py", line 214, in _make_script
    script = self._get_script_text(entry).encode('utf-8')
  File "/Users/pipermerriam/python-environments/eth-phone-number-verification/lib/python3.4/site-packages/pip/wheel.py", line 396, in _get_script_text
    "import_name": entry.suffix.split(".")[0],
AttributeError: 'NoneType' object has no attribute 'split'
```

And when trying to install with `python setup.py install` I got in import error because `jsonrpclib` was not yet installed.

### How was it fixed

* To fix the `AttributeError` I changed the structure of the `__main__.py` module so that it conforms to the [setuptools documentation](https://pythonhosted.org/setuptools/setuptools.html#automatic-script-creation)
* To fix the `python setup.py install` issue I removed the import of the `testrpc` module from the `__init__.py` module.


#### Cute animal picture

![kangaroo-in-diaper](https://cloud.githubusercontent.com/assets/824194/9317864/9005bd3a-44fb-11e5-9edb-e63fa3552be5.jpg)
