### PR TITLE
Make the rpc server usable outside of the command line

### DIFF
--- a/testrpc/__main__.py
+++ b/testrpc/__main__.py
@@ -9,10 +9,9 @@ parser.add_argument('-p', '--port', dest='port', type=int,
                     nargs='?', default=8545)
 parser.add_argument('-d', '--domain', dest='domain', type=str,
                     nargs='?', default='localhost')
-args = parser.parse_args()
 
 
-def create_server(host="127.0.0.1", port='8545'):
+def create_server(host="127.0.0.1", port=8545):
     server = SimpleJSONRPCServer((host, port), SimpleJSONRPCRequestHandlerWithCORS)
     server.register_function(eth_coinbase, 'eth_coinbase')
     server.register_function(eth_accounts, 'eth_accounts')
@@ -42,6 +41,7 @@ def create_server(host="127.0.0.1", port='8545'):
 
 
 def main():
+    args = parser.parse_args()
     evm_reset()
 
     t.set_logging_level(2)

--- a/testrpc/__main__.py
+++ b/testrpc/__main__.py
@@ -11,46 +11,51 @@ parser.add_argument('-d', '--domain', dest='domain', type=str,
                     nargs='?', default='localhost')
 args = parser.parse_args()
 
-############ Boot ############
 
-evm_reset()
+def create_server(host="127.0.0.1", port='8545'):
+    server = SimpleJSONRPCServer((host, port), SimpleJSONRPCRequestHandlerWithCORS)
+    server.register_function(eth_coinbase, 'eth_coinbase')
+    server.register_function(eth_accounts, 'eth_accounts')
+    server.register_function(eth_gasPrice, 'eth_gasPrice')
+    server.register_function(eth_blockNumber, 'eth_blockNumber')
+    server.register_function(eth_call, 'eth_call')
+    server.register_function(eth_sendTransaction, 'eth_sendTransaction')
+    server.register_function(eth_sendRawTransaction, 'eth_sendRawTransaction')
+    server.register_function(eth_getCompilers, 'eth_getCompilers')
+    server.register_function(eth_compileSolidity, 'eth_compileSolidity')
+    server.register_function(eth_getCode, 'eth_getCode')
+    server.register_function(eth_getBalance, 'eth_getBalance')
+    server.register_function(eth_getTransactionCount, 'eth_getTransactionCount')
+    server.register_function(eth_getTransactionByHash, 'eth_getTransactionByHash')
+    server.register_function(eth_getTransactionReceipt, 'eth_getTransactionReceipt')
+    server.register_function(eth_getBlockByNumber, 'eth_getBlockByNumber')
+    server.register_function(eth_newBlockFilter, 'eth_newBlockFilter')
+    server.register_function(eth_getFilterChanges, 'eth_getFilterChanges')
+    server.register_function(eth_uninstallFilter, 'eth_uninstallFilter')
+    server.register_function(web3_sha3, 'web3_sha3')
+    server.register_function(web3_clientVersion, 'web3_clientVersion')
+    server.register_function(evm_reset, 'evm_reset')
+    server.register_function(evm_snapshot, 'evm_snapshot')
+    server.register_function(evm_revert, 'evm_revert')
 
-t.set_logging_level(2)
-#slogging.configure(':info,eth.pb:debug,eth.vm.exit:trace')
-#slogging.configure(':info,eth.vm.exit:debug,eth.pb.tx:info')
+    return server
 
-print "\nAvailable Accounts\n=================="
-for account in accounts:
-    print '0x%s' % account.encode("hex")
-
-print "\nListening on %s:%s" % (args.domain, args.port)
-
-server = SimpleJSONRPCServer((args.domain, args.port), SimpleJSONRPCRequestHandlerWithCORS)
-server.register_function(eth_coinbase, 'eth_coinbase')
-server.register_function(eth_accounts, 'eth_accounts')
-server.register_function(eth_gasPrice, 'eth_gasPrice')
-server.register_function(eth_blockNumber, 'eth_blockNumber')
-server.register_function(eth_call, 'eth_call')
-server.register_function(eth_sendTransaction, 'eth_sendTransaction')
-server.register_function(eth_sendRawTransaction, 'eth_sendRawTransaction')
-server.register_function(eth_getCompilers, 'eth_getCompilers')
-server.register_function(eth_compileSolidity, 'eth_compileSolidity')
-server.register_function(eth_getCode, 'eth_getCode')
-server.register_function(eth_getBalance, 'eth_getBalance')
-server.register_function(eth_getTransactionCount, 'eth_getTransactionCount')
-server.register_function(eth_getTransactionByHash, 'eth_getTransactionByHash')
-server.register_function(eth_getTransactionReceipt, 'eth_getTransactionReceipt')
-server.register_function(eth_getBlockByNumber, 'eth_getBlockByNumber')
-server.register_function(eth_newBlockFilter, 'eth_newBlockFilter')
-server.register_function(eth_getFilterChanges, 'eth_getFilterChanges')
-server.register_function(eth_uninstallFilter, 'eth_uninstallFilter')
-server.register_function(web3_sha3, 'web3_sha3')
-server.register_function(web3_clientVersion, 'web3_clientVersion')
-server.register_function(evm_reset, 'evm_reset')
-server.register_function(evm_snapshot, 'evm_snapshot')
-server.register_function(evm_revert, 'evm_revert')
 
 def main():
+    evm_reset()
+
+    t.set_logging_level(2)
+    #slogging.configure(':info,eth.pb:debug,eth.vm.exit:trace')
+    #slogging.configure(':info,eth.vm.exit:debug,eth.pb.tx:info')
+
+    print "\nAvailable Accounts\n=================="
+    for account in accounts:
+        print '0x%s' % account.encode("hex")
+
+    print "\nListening on %s:%s" % (args.domain, args.port)
+
+    server = create_server(args.domain, args.port)
+
     server.serve_forever()
 
 


### PR DESCRIPTION
### What is the problem?

I need to use the `server` object from `testrpc.__main__` from within python codebase.  The current code instantiates the server using command line arguments for `host` and `port` which don't allow the flexibility that I need (ability to run on a different or dynamic port)

### How was this fixed.

I created a new function `create_server` in the `testrpc.__main__` module that handles the server creation.  This allows me to import this function so that I can generate new instances of the server.

#### Cute animal picture

![animals-in-pajamas-7](https://cloud.githubusercontent.com/assets/824194/9343826/9363e828-45c1-11e5-9d6f-1b1a57ef8cc3.jpg)
