### PR TITLE
wrap RPC calls in mutex

### DIFF
--- a/testrpc/__main__.py
+++ b/testrpc/__main__.py
@@ -5,6 +5,7 @@ from ethereum.tester import accounts
 import SocketServer
 from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCServer
 from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCRequestHandler
+from threading import Lock
 
 parser = argparse.ArgumentParser(
     description='Simulate an Ethereum blockchain JSON-RPC server.'
@@ -30,9 +31,29 @@ class SimpleJSONRPCRequestHandlerWithCORS(SimpleJSONRPCRequestHandler):
         self.send_header("Access-Control-Allow-Origin", "*")
         SimpleJSONRPCRequestHandler.end_headers(self)
 
+# When calling server.register_function, first wrap the function in a mutex.
+# This has the effect of serializing all RPC calls. Although we use a
+# multithreaded HTTP server, the EVM itself is not thread-safe, so we must take
+# care when interacting with it.
+evm_lock = Lock()
+def add_lock(server):
+    orig_reg_func = server.register_function
+    def reg_call(rpc_func, rpc_name):
+        def call(*args, **kwargs):
+            evm_lock.acquire()
+            try:
+                return rpc_func(*args, **kwargs)
+            finally:
+                evm_lock.release()
+
+        orig_reg_func(call, rpc_name)
+
+    server.register_function = reg_call
 
 def create_server(host="127.0.0.1", port=8545):
     server = ThreadingJSONRPCServer((host, port), SimpleJSONRPCRequestHandlerWithCORS)
+    add_lock(server)
+
     server.register_function(eth_coinbase, 'eth_coinbase')
     server.register_function(eth_accounts, 'eth_accounts')
     server.register_function(eth_gasPrice, 'eth_gasPrice')


### PR DESCRIPTION
This is an update to #29 
* Calls into the EVM need to be serialized as it is not thread-safe